### PR TITLE
Print warning(s) if user is not part of expected permission groups

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="pew3wm",
     packages=find_packages(where="src"),
-    install_requires=["evdev", "pyserial"],
+    install_requires=["evdev", "pyserial", "distro"],
     package_dir={"": "src"},
     extras_require={"lint": ["pre-commit"], "test": ["pytest", "py3status"]},
     entry_points={"py3status": ["module = pew3wm.pewpew"]},

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -23,16 +23,15 @@ def main():
 
 
 def warn_if_user_not_in_expected_groups():
-    expected_groups_by_distro = {
-        'arch': ['uucp'],
-        'ubuntu': ['input', 'dialout'],
-    }
+    expected_groups_by_distro = {"arch": ["uucp"], "ubuntu": ["input", "dialout"]}
     expected_groups = expected_groups_by_distro[distro.id()]
     user = getpass.getuser()
     groups = [g.gr_name for g in grp.getgrall() if user in g.gr_mem]
     for exp_group in expected_groups:
         if exp_group not in groups:
-            logger.info(f"Warning: user '{user}' is not in expected group: '{exp_group}'")
+            logger.info(
+                f"Warning: user '{user}' is not in expected group: '{exp_group}'"
+            )
 
 
 def deploy_pew_pew_control_module():

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -49,10 +49,10 @@ def deploy_pew_pew_control_module(containerPath):
 def deploy_py3status_module():
     configHomePath = Path(os.getenv("XDG_CONFIG_HOME", "~")).expanduser()
     candidates = [
-        configHomePath / ".config/py3status/modules",
-        configHomePath / ".config/i3status/py3status",
-        configHomePath / ".config/i3/py3status",
-        configHomePath / ".i3/py3status",
+        configHomePath / ".config" / "py3status" / "modules",
+        configHomePath / ".config" / "i3status" / "py3status",
+        configHomePath / ".config" / "i3" / "py3status",
+        configHomePath / ".i3" / "py3status",
     ]
     path = first_existing(candidates)
     if path is not None:

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -61,7 +61,7 @@ def deploy_py3status_module():
     candidates = [
         configHomePath / ".config/py3status/modules",
         configHomePath / ".config/i3status/py3status",
-        configHomePath / ".confi`g/i3/py3status",
+        configHomePath / ".config/i3/py3status",
         configHomePath / ".i3/py3status",
     ]
     path = first_existing(candidates)

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -21,7 +21,6 @@ def first_existing(candidates):
         print("Checking {}".format(candidate))
         if candidate.exists():
             return candidate
-        else:
     return None
 
 

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -65,7 +65,6 @@ def deploy_py3status_module():
 def warn_if_user_not_in_expected_groups():
     user = getpass.getuser()
     groups = [g.gr_name for g in grp.getgrall() if user in g.gr_mem]
-    groups = []
     expected_groups = ['input', 'dialout']
     for exp_group in expected_groups:
         if exp_group not in groups:

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -16,6 +16,16 @@ PY3STATUS_MODULE_PATH = HERE.parent / "src" / "pew3wm" / "pewpew.py"
 PY3STATUS_CONFIG_PATH = ""
 
 
+def main():
+    logging.basicConfig(level=logging.DEBUG)
+    warn_if_user_not_in_expected_groups()
+    containerPath = find_container_path()
+    if containerPath is None:
+        raise Exception("Could not find pewpew; check cable!")
+    deploy_pew_pew_control_module(containerPath)
+    deploy_py3status_module()
+
+
 def first_existing(candidates):
     for candidate in candidates:
         print("Checking {}".format(candidate))
@@ -69,16 +79,6 @@ def warn_if_user_not_in_expected_groups():
     for exp_group in expected_groups:
         if exp_group not in groups:
             print("Warning: user '{}' is not in expected group: '{}'".format(user, exp_group))
-
-
-def main():
-    logging.basicConfig(level=logging.DEBUG)
-    warn_if_user_not_in_expected_groups()
-    containerPath = find_container_path()
-    if containerPath is None:
-        raise Exception("Could not find pewpew; check cable!")
-    deploy_pew_pew_control_module(containerPath)
-    deploy_py3status_module()
 
 
 if __name__ == "__main__":

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -12,7 +12,7 @@ from pathlib import Path
 log = logging.getLogger(__name__)
 HERE = Path(__file__).parent
 MODULE_NAME = "code.py"
-PY3STATUS_MODULE_PATH = HERE.parent / "src" / "pew3wm" / "pewpew.py"
+PY3STATUS_MODULE_PATH = HERE.parent / "src/pew3wm/pewpew.py"
 PY3STATUS_CONFIG_PATH = ""
 
 
@@ -59,10 +59,10 @@ def deploy_pew_pew_control_module(containerPath):
 def deploy_py3status_module():
     configHomePath = Path(os.getenv("XDG_CONFIG_HOME", "~")).expanduser()
     candidates = [
-        configHomePath / ".config" / "py3status" / "modules",
-        configHomePath / ".config" / "i3status" / "py3status",
-        configHomePath / ".config" / "i3" / "py3status",
-        configHomePath / ".i3" / "py3status",
+        configHomePath / ".config/py3status/modules",
+        configHomePath / ".config/i3status/py3status",
+        configHomePath / ".confi`g/i3/py3status",
+        configHomePath / ".i3/py3status",
     ]
     path = first_existing(candidates)
     if path is not None:

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -1,11 +1,10 @@
-# Standard
+# coding: utf-8
 import getpass
 import grp
 import logging
 import os
 import shutil
 
-# Cheese shop
 from pathlib import Path
 
 

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -69,7 +69,7 @@ def deploy_py3status_module():
         log.info(f"deploy py3status module {PY3STATUS_MODULE_PATH} to {path}")
         shutil.copy(PY3STATUS_MODULE_PATH, path)
     else:
-        raise Exception("Could not find a home for {}".format(MODULE_NAME))
+        raise Exception(f"Could not find a home for {MODULE_NAME}")
 
 
 def warn_if_user_not_in_expected_groups():
@@ -78,7 +78,7 @@ def warn_if_user_not_in_expected_groups():
     expected_groups = ['input', 'dialout']
     for exp_group in expected_groups:
         if exp_group not in groups:
-            print("Warning: user '{}' is not in expected group: '{}'".format(user, exp_group))
+            print("Warning: user '{user}' is not in expected group: '{exp_group}'")
 
 
 if __name__ == "__main__":

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -74,10 +74,10 @@ def warn_if_user_not_in_expected_groups():
 
 def main():
     logging.basicConfig(level=logging.DEBUG)
+    warn_if_user_not_in_expected_groups()
     containerPath = find_container_path()
     if containerPath is None:
         raise Exception("Could not find pewpew; check cable!")
-    warn_if_user_not_in_expected_groups()
     deploy_pew_pew_control_module(containerPath)
     deploy_py3status_module()
 

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -5,8 +5,8 @@ import logging
 import os
 import shutil
 
+import distro
 from pathlib import Path
-
 
 log = logging.getLogger(__name__)
 HERE = Path(__file__).parent
@@ -72,12 +72,16 @@ def deploy_py3status_module():
 
 
 def warn_if_user_not_in_expected_groups():
+    expected_groups_by_distro = {
+        'arch': ['uucp'],
+        'ubuntu': ['input', 'dialout'],
+    }
+    expected_groups = expected_groups_by_distro[distro.id()]
     user = getpass.getuser()
     groups = [g.gr_name for g in grp.getgrall() if user in g.gr_mem]
-    expected_groups = ['input', 'dialout']
     for exp_group in expected_groups:
         if exp_group not in groups:
-            print("Warning: user '{user}' is not in expected group: '{exp_group}'")
+            logger.info(f"Warning: user '{user}' is not in expected group: '{exp_group}'")
 
 
 if __name__ == "__main__":

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -9,6 +9,7 @@ import distro
 from pathlib import Path
 
 log = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)
 HERE = Path(__file__).parent
 MODULE_NAME = "code.py"
 PY3STATUS_MODULE_PATH = HERE.parent / "src/pew3wm/pewpew.py"
@@ -16,7 +17,6 @@ PY3STATUS_CONFIG_PATH = ""
 
 
 def main():
-    logging.basicConfig(level=logging.DEBUG)
     warn_if_user_not_in_expected_groups()
     deploy_pew_pew_control_module()
     deploy_py3status_module()

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -29,9 +29,7 @@ def warn_if_user_not_in_expected_groups():
     groups = [g.gr_name for g in grp.getgrall() if user in g.gr_mem]
     for exp_group in expected_groups:
         if exp_group not in groups:
-            logger.info(
-                f"Warning: user '{user}' is not in expected group: '{exp_group}'"
-            )
+            log.info(f"Warning: user '{user}' is not in expected group: '{exp_group}'")
 
 
 def deploy_pew_pew_control_module():

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -1,7 +1,11 @@
+# Standard
 import getpass
+import grp
 import logging
 import os
 import shutil
+
+# Cheese shop
 from pathlib import Path
 
 
@@ -14,8 +18,10 @@ PY3STATUS_CONFIG_PATH = ""
 
 def first_existing(candidates):
     for candidate in candidates:
+        print("Checking {}".format(candidate))
         if candidate.exists():
             return candidate
+        else:
     return None
 
 
@@ -26,15 +32,6 @@ def find_container_path():
         Path(f"/media/{user}/CIRCUITPY"),
     ]
     return first_existing(candidates)
-
-
-def main():
-    logging.basicConfig(level=logging.DEBUG)
-    containerPath = find_container_path()
-    if containerPath is None:
-        raise Exception("Could not find pewpew; check cable!")
-    deploy_pew_pew_control_module(containerPath)
-    deploy_py3status_module()
 
 
 def deploy_pew_pew_control_module(containerPath):
@@ -63,7 +60,27 @@ def deploy_py3status_module():
         log.info(f"deploy py3status module {PY3STATUS_MODULE_PATH} to {path}")
         shutil.copy(PY3STATUS_MODULE_PATH, path)
     else:
-        raise Exception("Could not find a home for pewpew")
+        raise Exception("Could not find a home for {}".format(MODULE_NAME))
+
+
+def warn_if_user_not_in_expected_groups():
+    user = getpass.getuser()
+    groups = [g.gr_name for g in grp.getgrall() if user in g.gr_mem]
+    groups = []
+    expected_groups = ['input', 'dialout']
+    for exp_group in expected_groups:
+        if exp_group not in groups:
+            print("Warning: user '{}' is not in expected group: '{}'".format(user, exp_group))
+
+
+def main():
+    logging.basicConfig(level=logging.DEBUG)
+    containerPath = find_container_path()
+    if containerPath is None:
+        raise Exception("Could not find pewpew; check cable!")
+    warn_if_user_not_in_expected_groups()
+    deploy_pew_pew_control_module(containerPath)
+    deploy_py3status_module()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
One of the reasons I couldn't get pewpew working on my i3 machines, was that my user was not part of the 'input' group.

I added a check for the 'expected groups' of the deploying user in the script; the expected groups vary from distribution so this is specific to Ubuntu. Please help generalize!