### PR TITLE
warn if target != source after deploy

### DIFF
--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -47,6 +47,7 @@ def deploy_pew_pew_control_module(containerPath):
         print(f"move existing {dstPath} to {backupPath}")
         dstPath.rename(backupPath)
     shutil.copy(srcPath, dstPath)
+    assert srcPath.read_bytes() == dstPath.read_bytes(), "Target != Source; deploy fail?"
     print(f"deployed control module to {dstPath}")
 
 


### PR DESCRIPTION
A simple sanity check: code.py bytes should be equal in source and target folders after deployment