### PR TITLE
Approval test and pewpew.py thread refactor

### DIFF
--- a/src/pew3wm/pewpew.py
+++ b/src/pew3wm/pewpew.py
@@ -108,19 +108,18 @@ class PewPewEvents(threading.Thread):
         return list[self.device.read_loop()]
 
     def _try(self):
-        # import pdb; pdb.set_trace()
         try:
             if self.device is None:
                 self._set_device(self.get_pewpew_device())
                 self._set_state(None)
 
             for event in self._get_events():
-                event_tuple = event.type, event.code, event.value
-                new_state = event_map.get(event_tuple, None)
+                (t, c, v) = event.type, event.code, event.value
+                new_state = event_map.get((t, c, v), None)
                 if new_state is not None:
                     self._set_state(new_state)
                 else:
-                    self._say(f"Ignoring event {event_tuple}")
+                    self._say(f"Ignoring event ({t}, {c}, {v})")
 
         except Exception:
             if self.state is not False:

--- a/src/pew3wm/pewpew.py
+++ b/src/pew3wm/pewpew.py
@@ -81,7 +81,7 @@ class PewPewEvents(threading.Thread):
         self.parent = parent
         self._say("Initialized")
 
-    def _say(msg):
+    def _say(self, msg):
         pass
 
     def _set_device(self, device):

--- a/src/pew3wm/pewpew.py
+++ b/src/pew3wm/pewpew.py
@@ -114,12 +114,12 @@ class PewPewEvents(threading.Thread):
                 self._set_state(None)
 
             for event in self._get_events():
-                (t, c, v) = event.type, event.code, event.value
-                new_state = event_map.get((t, c, v), None)
+                event_tuple = event.type, event.code, event.value
+                new_state = event_map.get(event_tuple, None)
                 if new_state is not None:
                     self._set_state(new_state)
                 else:
-                    self._say(f"Ignoring event ({t}, {c}, {v})")
+                    self._say(f"Ignoring event {event_tuple}")
 
         except Exception:
             if self.state is not False:

--- a/src/pew3wm/pewpew.py
+++ b/src/pew3wm/pewpew.py
@@ -115,12 +115,12 @@ class PewPewEvents(threading.Thread):
                 self._set_state(None)
 
             for event in self._get_events():
-                (t, c, v) = event.type, event.code, event.value
-                new_state = event_map.get((t, c, v), None)
+                event_tuple = event.type, event.code, event.value
+                new_state = event_map.get(event_tuple, None)
                 if new_state is not None:
                     self._set_state(new_state)
                 else:
-                    self._say(f"Ignoring event ({t}, {c}, {v})")
+                    self._say(f"Ignoring event {event_tuple}")
 
         except Exception:
             if self.state is not False:

--- a/tests/test_pewpew.py
+++ b/tests/test_pewpew.py
@@ -21,10 +21,6 @@ log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)
 
 
-def test_sanity():
-    assert PewPewEvents
-
-
 def test_pewpew_behaviour():
     class FakeParent:
         def __init__(self):

--- a/tests/test_pewpew.py
+++ b/tests/test_pewpew.py
@@ -1,7 +1,21 @@
 import logging
+from collections import namedtuple
 
-from pew3wm.pewpew import PewPewEvents
 
+from pew3wm.pewpew import (
+    PewPewEvents,
+    ACTION_EVENT,
+    AXIS_EVENT,
+    AXIS_HORIZONTAL,
+    AXIS_VERTICAL,
+    BUTTON_DOWN,
+    BUTTON_K0,
+    BUTTON_K1,
+    MAJOR,
+    MINOR,
+)
+
+event = namedtuple("event", ["type", "code", "value"])
 
 log = logging.getLogger(__name__)
 
@@ -15,5 +29,42 @@ def test_pewpew_behaviour():
         def __init__(self):
             self.py3 = {}
 
+    said = []
+
+    def say(something):
+        said.append(something)
+
     parent = FakeParent()
-    PewPewEvents(parent)
+    dut = PewPewEvents(parent, say)  # dut; Device Under Test
+    dut.get_pewpew_device = lambda: "test"
+
+    fake_events = [
+        event(AXIS_EVENT, AXIS_HORIZONTAL, MINOR),
+        event(AXIS_EVENT, AXIS_HORIZONTAL, MAJOR),
+        event(AXIS_EVENT, AXIS_VERTICAL, MINOR),
+        event(AXIS_EVENT, AXIS_VERTICAL, MINOR - 20),
+        event(AXIS_EVENT, AXIS_VERTICAL, MAJOR),
+        event(ACTION_EVENT, BUTTON_K0, BUTTON_DOWN),
+        event(1, 2, 3),
+        event(ACTION_EVENT, BUTTON_K1, BUTTON_DOWN),
+    ]
+    dut._get_events = lambda: fake_events
+    dut.device = None
+    dut._try()
+
+    expected = [
+        "Setting device to None",
+        "Initialized",
+        "Setting device to test",
+        "Setting state to None",
+        "Setting state to LEFT",
+        "Setting state to RIGHT",
+        "Setting state to UP",
+        "Ignoring event (3, 1, -147)",
+        "Setting state to DOWN",
+        "Setting state to K0",
+        "Ignoring event (1, 2, 3)",
+        "Setting state to K1",
+    ]
+    print(said)
+    assert said == expected

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -45,7 +45,9 @@ def deploy_pew_pew_control_module():
         print(f"move existing {dstPath} to {backupPath}")
         dstPath.rename(backupPath)
     shutil.copy(srcPath, dstPath)
-    assert srcPath.read_bytes() == dstPath.read_bytes(), "Target != Source; deploy fail?"
+    assert (
+        srcPath.read_bytes() == dstPath.read_bytes()
+    ), "Target != Source; deploy fail?"
     print(f"deployed control module to {dstPath}")
 
 


### PR DESCRIPTION
While adding an approval test (test_pewpew.py) I refactored the "run" function of the thread.

It's been running some hours on my machine and seems to work fine.

@ultrabug you might want to have a look, also at the test_pewpew module. It's a little dirty ATM I think it can be cleaned up quite a bit by pytest decorators (I'm new to pytest so @obestwalter probably pukes a little when he sees the test haha)